### PR TITLE
[WIP] Availability vacation search

### DIFF
--- a/src/availability.js
+++ b/src/availability.js
@@ -22,10 +22,35 @@ const getSectionId = (project, sectionName) => client.sections.findByProject(pro
     return section ? section.gid : false
   })
 
+// https://developers.asana.com/docs/#tocS_CustomField
+// https://developers.asana.com/docs/#search-tasks-in-a-workspace
+/*
+  custom_fields:
+   [
+      {
+        gid: '1159688855981996',
+        enabled: true,
+        enum_options: [Array],
+        enum_value: [Object],
+        name: 'Status',
+        resource_subtype: 'enum',
+        resource_type: 'custom_field',
+        type: 'enum',
+      },
+    ],
+*/
+// this requires project-wide custom field (manual in Asana)
+// TODO: search using project or something else
+const getCustomFieldsByWorkspace = (wsId) => client.customFields
+  .findByWorkspace(wsId).then((res) => res.data)
+
 // params.section
 // params.workspace
 // params.project
 const getTasks = (params) => client.tasks.findAll(params).then((res) => res.data)
+const getTasksForWorkspace = (workspace, params) => client.tasks.searchInWorkspace(workspace, params)
+  .then((res) => res.data)
+const updateTask = (taskId, params) => client.tasks.update(taskId, params).then((res) => res)
 
 /* example utils
 


### PR DESCRIPTION
Current latest version is out of sync: https://www.npmjs.com/package/@eqworks/avail-bot
Deployed a local version to add customFields, but never merged

This PR will address the gap and try to handle a few quirky cases related to dates:
- get all tasks that are `due_on` today
- handle `due_at` within a day
- get date ranges (e.g. vacation)

Though from tests, it will require multiple queries, due to how Asana handles dates.